### PR TITLE
Fix klib include directory

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -84,7 +84,7 @@ foreach(TARGET ${TARGETS})
       ${OPENSSL_ROOT_DIR}/include
       ${LIBEV_INCLUDE}
       ${WARP_INCLUDE}
-      $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/external/klib>
+      $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/external/klib>
     PRIVATE
       $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/external/include>
   )


### PR DESCRIPTION
`PROJECT_SOURCE_DIR` preserves the current project root