### PR TITLE
Changes to compile on FreeBSD-13-CURRENT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,8 +70,8 @@ foreach(FLAG -pipe -Wextra -Wpedantic -Weverything -Werror
         -Wno-extra-semi-stmt # the kh_foreach* macros need this
         -Wno-macro-redefined # because we redefine _FORTIFY_SOURCE
         -Wno-covered-switch-default -Wno-missing-braces
+        -Wno-gnu-statement-expression
         -fcomment-block-commands=dotfile
-	-Wno-gnu-statement-expression
         )
   string(REGEX REPLACE "[-=+]" "_" F ${FLAG})
   check_c_compiler_flag(${FLAG} ${F})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,7 @@ foreach(FLAG -pipe -Wextra -Wpedantic -Weverything -Werror
         -Wno-macro-redefined # because we redefine _FORTIFY_SOURCE
         -Wno-covered-switch-default -Wno-missing-braces
         -fcomment-block-commands=dotfile
+	-Wno-gnu-statement-expression
         )
   string(REGEX REPLACE "[-=+]" "_" F ${FLAG})
   check_c_compiler_flag(${FLAG} ${F})

--- a/bin/client.c
+++ b/bin/client.c
@@ -40,6 +40,7 @@
 #include <string.h>
 #include <sys/param.h>
 #include <sys/socket.h> // IWYU pragma: no_forward_declare sockaddr
+#include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/uio.h>
 #include <time.h>

--- a/lib/src/conn.c
+++ b/lib/src/conn.c
@@ -42,6 +42,7 @@
 #endif
 
 #if !defined(PARTICLE) && !defined(RIOT_VERSION)
+#include <netinet/in.h>
 #include <netinet/ip.h>
 #endif
 

--- a/lib/src/frame.c
+++ b/lib/src/frame.c
@@ -33,6 +33,7 @@
 #include <sys/socket.h>
 
 #if !defined(PARTICLE) && !defined(RIOT_VERSION)
+#include <netinet/in.h>
 #include <netinet/ip.h>
 #endif
 

--- a/lib/src/pkt.c
+++ b/lib/src/pkt.c
@@ -31,6 +31,7 @@
 #include <sys/param.h>
 
 #if !defined(PARTICLE) && !defined(RIOT_VERSION)
+#include <netinet/in.h>
 #include <netinet/ip.h>
 #endif
 


### PR DESCRIPTION
I needed to add some #includes, and tell CLANG to shut up about GCC'isms to compile on FreeBSD-13-CURRENT.

It think the #include fixes are pretty straight-forward, but personally I would probably try to avoid the GCC'isms, rather than muffle CLANG.