### PR TITLE
netinet/in.h is required for netinet/ip.h on FreeBSD

### DIFF
--- a/lib/src/conn.c
+++ b/lib/src/conn.c
@@ -41,12 +41,12 @@
 #include <sys/socket.h>
 #endif
 
-#if !defined(PARTICLE) && !defined(RIOT_VERSION)
-#include <netinet/ip.h>
-#endif
-
 #ifdef __FreeBSD__
 #include <netinet/in.h>
+#endif
+
+#if !defined(PARTICLE) && !defined(RIOT_VERSION)
+#include <netinet/ip.h>
 #endif
 
 #include <picotls.h>

--- a/lib/src/frame.c
+++ b/lib/src/frame.c
@@ -32,12 +32,12 @@
 #include <sys/param.h>
 #include <sys/socket.h>
 
-#if !defined(PARTICLE) && !defined(RIOT_VERSION)
-#include <netinet/ip.h>
-#endif
-
 #ifdef __FreeBSD__
 #include <netinet/in.h>
+#endif
+
+#if !defined(PARTICLE) && !defined(RIOT_VERSION)
+#include <netinet/ip.h>
 #endif
 
 #include <picotls.h>

--- a/lib/src/pkt.c
+++ b/lib/src/pkt.c
@@ -30,12 +30,12 @@
 #include <string.h>
 #include <sys/param.h>
 
-#if !defined(PARTICLE) && !defined(RIOT_VERSION)
-#include <netinet/ip.h>
-#endif
-
 #ifdef __FreeBSD__
 #include <netinet/in.h>
+#endif
+
+#if !defined(PARTICLE) && !defined(RIOT_VERSION)
+#include <netinet/ip.h>
 #endif
 
 #include <picotls.h>


### PR DESCRIPTION
On FreeBSD `<netinet/ip.h>` uses `struct in_addr` so `<netinet/in.h>` must come first.

In general I consider the `#ifdef __FreeBSD__` surplus to requirements as `struct in_addr` has always been defined in `<netinet/in.h>` on any BSD/socket based implementation.